### PR TITLE
add Github Actions automation

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -78,4 +78,4 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -m "bump chart version to ${{ needs.publish_release.outputs.chart_tag }}"
-          git push origin ${{ env.branch }}
+          git push origin ${{ env.pages_branch }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,4 +1,4 @@
-name: release_flow
+name: helm_release
 
 on: 
   pull_request:

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,0 +1,81 @@
+name: release_flow
+
+on: 
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  publish_release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      tag_release_outcome: ${{ steps.tag_release_output.outputs.tag_release_outcome }}
+      chart_tag: ${{ steps.chart_tag_output.outputs.chart_tag }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get chart.yaml tag
+        run: |
+          echo "chart_tag=$(grep '^version: ' ${GITHUB_WORKSPACE}/Chart.yaml | sed 's/version: //g')" >> $GITHUB_ENV
+      - name: Check for tag
+        run: |
+          echo "repo_tag=$(git tag -l ${{ env.chart_tag }})" >> $GITHUB_ENV
+      - name: Conditionally tag release
+        id: tag_release
+        if: env.chart_tag != env.repo_tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ env.chart_tag }}
+          release_name: ${{ env.chart_tag }}
+          commitish: main
+          body: ""
+          draft: false
+          prerelease: false
+      - name: Set output tag_release_outcome
+        id: tag_release_output
+        run: |
+          echo "::set-output name=tag_release_outcome::${{ steps.tag_release.outcome }}"
+      - name: Set output "chart_tag"
+        id: chart_tag_output
+        run: |
+          echo "::set-output name=chart_tag::${{ env.chart_tag }}"
+
+  helm_package:
+    needs: publish_release
+    if: needs.publish_release.outputs.tag_release_outcome == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.2
+
+      - name: Create package and push
+        env:
+          pages_branch: gh-pages
+          target_branch: main
+        run: |
+          git checkout ${{ env.target_branch }}
+          cp -v README.md ..
+          cd ${GITHUB_WORKSPACE}/..
+          helm --debug package benthos-helm-chart
+          cd benthos-helm-chart
+          git checkout ${{ env.pages_branch }}
+          mv -v ../README.md .
+          mv -v ../benthos-*.tgz .
+          helm --debug repo index . --url https://benthosdev.github.io/benthos-helm-chart/
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "bump chart version to ${{ needs.publish_release.outputs.chart_tag }}"
+          git push origin ${{ env.branch }}


### PR DESCRIPTION
Upon a PR merge to main, this automation will:
- Check chart tag in Chart.yaml
- Tag a release if chart tag does not yet exist on the repo
- Package the latest version into a helm chart tarball
- Capture tarball and README.md to sync to gh-pages branch
- Updates gh-pages branch, README.md, and indexes helm repo post-copy