### PR TITLE
Remove read timeout form http endpoint since config sanitization fails

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -11,7 +11,6 @@ data:
       enabled: {{ .Values.http.enabled }}
       {{- if .Values.http.enabled }}
       address: {{ .Values.http.address | default "0.0.0.0:4195" }}
-      read_timeout: {{ .Values.http.readTimeout | default "5s" }}
       root_path: {{ .Values.http.rootPath | default "/benthos" }}
       debug_endpoints: {{ .Values.http.debugEndpoints | default false }}
       {{- end -}}


### PR DESCRIPTION
if read_timeout is set benthos wont start. Unrecognized option.

```
INFO Running main config from specified file       @service=benthos path=./config.yaml
ERRO Config lint error                             @service=benthos lint="./config.yaml(5,1) field read_timeout not recognised"
ERRO Shutting down due to linter errors, to prevent shutdown run Benthos with --chilled  @service=benthos
```

