### PR TITLE
Disable HTTP liveness and readiness probes when HTTP endpoint is disabled

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - name: http
               containerPort: 4195
               protocol: TCP
+          {{- if .Values.http.enabled -}}
           livenessProbe:
             httpGet:
               path: /ping
@@ -70,6 +71,7 @@ spec:
               {{- if .Values.http.tls.enabled }}
               scheme: HTTPS
               {{- end }}
+          {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
           resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: http
               containerPort: 4195
               protocol: TCP
-          {{- if .Values.http.enabled -}}
+          {{- if .Values.http.enabled }}
           livenessProbe:
             httpGet:
               path: /ping


### PR DESCRIPTION
Disalbe HTTP probes when the HTTP endpoint is disabled. Pod Will end up in an unhealthy state always.

