### PR TITLE
Allow custom yaml in extraVolumes to support resources like csi drivers

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -119,16 +119,8 @@ spec:
           secret:
             secretName: {{ .Values.http.tls.secretName }}
         {{- end }}
-        {{- range .Values.extraVolumes }}
-        - name: {{ .name }}
-          {{- if .configMap }}
-          configMap:
-            name: {{ .configMap.name }}
-          {{- end }}
-          {{- if .secret }}
-          secret:
-            secretName: {{ .secret.secretName }}
-          {{- end }}
+        {{- if .Values.extraVolumes }}
+          {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
         {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
         - name: streams


### PR DESCRIPTION
Need to add extra csi volume mount like so, but current chart does not allow this:

```
- name: secrets-store
  csi:
    driver: secrets-store.csi.k8s.io
    readOnly: true
    volumeAttributes:
      secretProviderClass: svc-benthos-secrets
```