### PR TITLE
feat: add observability config

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.11.0"
+appVersion: "4.22.0"

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -7,6 +7,14 @@ metadata:
     {{- include "benthos.labels" . | nindent 4 }}
 data:
   benthos.yaml: |
+    {{- with .Values.metrics }}
+    metrics:
+      {{- toYaml . | nindent 6}} 
+    {{- end }}
+    {{- with .Values.tracing }}
+    tracers:
+      {{- toYaml . | nindent 6}}
+    {{- end }}
     http:
       enabled: {{ .Values.http.enabled }}
       {{- if .Values.http.enabled }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "benthos.fullname" . }}
+  labels:
+    {{- include "benthos.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval}}
+      targetPort: http
+      path: /metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "benthos.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -158,6 +158,19 @@ http:
     # Create a secret of type `kubernetes.io/tls` in the same namespace and add the name here
     # secretName: ""
 
+serviceMonitor:
+  enabled: false
+  interval: "10s"
+
+# metrics:
+#   prometheus: {}
+#
+# tracing:
+#   openTelemetry:
+#     http: []
+#     grpc: []
+#     tags: {}
+
 # command -- Command replaces the entrypoint command of the docker
 command: []
 


### PR DESCRIPTION
This PR adds support for configuring `tracers:` and `metrics:` through the chart. The reason for this is so when extending Benthos as a subchart you can configure default tracers/metrics without interfering with the config.

It also adds a `serviceMonitor` option to enable a ServiceMonitor for the `/metrics` endpoints