### PR TITLE
Added topologySpreadConstraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ For more information on configuring the HTTP component, refer to the [Benthos HT
 | podDisruptionBudget.minAvailable              | Min number of pods available at all times        | ""                 |
 | podDisruptionBudget.maxUnavailable            | Max unavailable number of pods                   | ""                 |
 | watch                                         | Enables watch mode                               | false              |
+| topologySpreadConstraints                     | Configure topology spread constraints            | []                 |
 | initContainers                                | Add any custom init container                    | []                 |
 | config                                        | Benthos component configuration                  | ""                 |
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -129,6 +129,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with  .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config
           configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -167,5 +167,8 @@ args: []
 # EXPERIMENTAL: watch config files for changes and automatically apply them
 watch: false
 
+# Spread  incoming Pod in relation to the existing Pods across your cluster. https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+topologySpreadConstraints: []
+
 # /benthos.yaml configuration
 config: |


### PR DESCRIPTION
Added : `topologySpreadConstraints` for pod configs.
https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field