### PR TITLE
Allow using custom image repository

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.command }}
           command:

--- a/values.yaml
+++ b/values.yaml
@@ -45,6 +45,7 @@ deployment:
 commonLabels: {}
 
 image:
+  registry: docker.io
   repository: "jeffail/benthos"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
In some on-prem environments users wish to pull from a local registry/repository as opposed to pulling from docker.io

This PR sets the default `image.registry: docker.io` and adds `image.registry` to the `image:` of the deployment.yaml template.